### PR TITLE
Overrides float in search results pages

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -189,3 +189,7 @@ select::-ms-expand {
     }
   }
 }
+
+.content--catalog {
+  float: initial;
+}


### PR DESCRIPTION
Before: 
<img width="871" alt="Screen Shot 2019-07-19 at 2 25 19 PM" src="https://user-images.githubusercontent.com/8161144/61557009-21e0a280-aa31-11e9-910a-6a67c1693174.png">
After:
<img width="858" alt="Screen Shot 2019-07-19 at 2 25 12 PM" src="https://user-images.githubusercontent.com/8161144/61557021-26a55680-aa31-11e9-9fdf-b356d92ec340.png">

@kevinreiss This is on https://dss-staging.princeton.edu/?utf8=%E2%9C%93&search_field=all_fields&q=