### PR TITLE
Updating to fix cap version error on robots

### DIFF
--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -1,5 +1,5 @@
 # config valid only for current version of Capistrano
-lock '3.7.2'
+lock '3.16.0'
 
 set :application, 'dss'
 set :repo_url, 'https://github.com/pulibrary/DSS.git'


### PR DESCRIPTION
Fixes
```
(Backtrace restricted to imported tasks)
cap aborted!
Capfile locked at 3.7.2, but 3.16.0 is loaded

Tasks: TOP => staging
(See full trace by running task with --trace)
```