### PR TITLE
Address Capistrano deprecation warning

### DIFF
--- a/Capfile
+++ b/Capfile
@@ -25,6 +25,7 @@ require 'capistrano/passenger'
 require 'whenever/capistrano'
 
 require "capistrano/scm/git"
+install_plugin Capistrano::SCM::Git
 require 'capistrano/yarn'
 
 # Load custom tasks from `lib/capistrano/tasks` if you have any defined


### PR DESCRIPTION
From Heaven deployment

```
From https://github.com/pulibrary/DSS
 * [new branch]      upgrade_bundler -> origin/upgrade_bundler
[Deprecation Notice] Future versions of Capistrano will not load the Git SCM
plugin by default. To silence this deprecation warning, add the following to
your Capfile after `require "capistrano/deploy"`:

    require "capistrano/scm/git"
    install_plugin Capistrano::SCM::Git
```