### PR TITLE
Reintroduce quick links

### DIFF
--- a/app/views/catalog/_facets.html.erb
+++ b/app/views/catalog/_facets.html.erb
@@ -1,5 +1,0 @@
-<% blacklight_config.facet_group_names.each do |groupname| %>
-  <%= render 'facet_group', groupname: groupname %>
-<% end %>
-
-<%= render 'shared/quick-links' %>

--- a/app/views/catalog/index.html.erb
+++ b/app/views/catalog/index.html.erb
@@ -1,6 +1,10 @@
 <div class="container--catalog">
   <div id="sidebar" class="lside--catalog <%= has_search_parameters? %>">
-    <%= render 'search_sidebar' %>
+      <% conf = blacklight_config.view_config(document_index_view_type) %>
+      <%= render conf.sidebar_component.new(blacklight_config: blacklight_config,
+                                            response: @response,
+                                            view_config: conf) %>
+      <%= render 'shared/quick-links' %>
   </div>
 
   <div id="content" class="content--catalog <%= has_search_parameters? %>">

--- a/spec/system/home_page_spec.rb
+++ b/spec/system/home_page_spec.rb
@@ -7,6 +7,12 @@ describe "home page", type: :system, js: true do
     visit '/catalog'
     expect(html_errors('Unexpected end tag')).to be_empty
   end
+
+  it 'has facets' do
+    visit '/catalog'
+    expect(page).to have_content('Data Catalog')
+    expect(page).to have_content('Quick Links')
+  end
 end
 
 def html_errors(error_name)


### PR DESCRIPTION
- Use sidebar_component rather than deprecated partial
- Put quick-links in index.html.erb

Co-authored-by: regineheberlein <regineheberlein@users.noreply.github.com>