### PR TITLE
Remove listen gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -55,7 +55,6 @@ end
 group :development do
   # Access an IRB console on exception pages or by using <%= console %> anywhere in the code.
   gem 'web-console'
-  gem 'listen', '~> 3.0.5'
   gem 'capistrano-passenger'
 end
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -200,9 +200,6 @@ GEM
       activerecord
       kaminari-core (= 1.2.2)
     kaminari-core (1.2.2)
-    listen (3.0.8)
-      rb-fsevent (~> 0.9, >= 0.9.4)
-      rb-inotify (~> 0.9, >= 0.9.7)
     loofah (2.20.0)
       crass (~> 1.0.2)
       nokogiri (>= 1.5.9)
@@ -296,9 +293,6 @@ GEM
       zeitwerk (~> 2.5)
     rainbow (3.1.1)
     rake (13.0.6)
-    rb-fsevent (0.11.2)
-    rb-inotify (0.10.1)
-      ffi (~> 1.0)
     regexp_parser (2.6.2)
     responders (3.0.1)
       actionpack (>= 5.0)
@@ -440,7 +434,6 @@ DEPENDENCIES
   honeybadger (~> 4.12)
   jbuilder (~> 2.5)
   jquery-rails
-  listen (~> 3.0.5)
   omniauth-cas
   pg
   pry-byebug

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -47,8 +47,4 @@ Rails.application.configure do
 
   # Raises error for missing translations
   # config.action_view.raise_on_missing_translations = true
-
-  # Use an evented file watcher to asynchronously detect changes in source code,
-  # routes, locales, etc. This feature depends on the listen gem.
-  config.file_watcher = ActiveSupport::EventedFileUpdateChecker
 end


### PR DESCRIPTION
When I tried DSS with Rails 7.1, it gave me errors about this gem.  I don't think we really need it for the development experience.