### PR TITLE
Improve view of admin menu

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -78,7 +78,10 @@ $link-color: #2762ae;
 }
 
 main > .container {
-  padding: 0 1em;
+  margin-left: 0;
+  margin-right: 0;
+  max-width: 100vw;
+  padding: 0;
 }
 
 .datatable .limit-width {
@@ -263,4 +266,31 @@ select::-ms-expand {
 .lux-header-content {
   max-width: none !important;
   padding: 0 2rem !important;
+}
+
+.menu__admin {
+  padding: 0;
+  margin: 0;
+}
+
+.menu--horizontal {
+  border-radius: 0;
+}
+
+.menu--horizontal li {
+  float: left;
+  padding: 0.7rem 1.5rem;
+  text-align: center;
+}
+
+.menu li {
+  text-align: center;
+  a {
+    padding-top: 0.5rem;
+    padding-bottom: 0.5rem;
+  }
+  a:hover {
+    background-color: grey;
+    color: white;
+  }
 }


### PR DESCRIPTION
1. This version makes it so the admin menu spans 100% of the width of the screen
2. It modifies the 'Terms' dropdown menu so that the background of the links turns grey when you hover over them (for accessibility purposes, in addition to looking nicer)
<img width="1512" alt="Screenshot 2023-11-17 at 3 00 44 PM" src="https://github.com/pulibrary/DSS/assets/113146215/52c55663-5d26-42a7-b4e6-8a77dfa81ecb">
