### PR TITLE
Fix visual regression in non-admin screens

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -306,7 +306,7 @@ select::-ms-expand {
   background-color:#23578b;
 }
 
-.row {
+.row.admin {
   display: flex;
   flex-wrap: wrap;
   margin-right: -15px;

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -11,6 +11,12 @@ module ApplicationHelper
     end
   end
 
+  # All screens handled by the catalog controller are public screens
+  # All other screens are considered "admin" screens
+  def admin_screen?
+    controller_name != 'catalog'
+  end
+
   # rubocop:disable  Rails/OutputSafety
   def html_safe(args)
     args[:document][args[:field]].join('').gsub("\\'", '').html_safe
@@ -40,7 +46,7 @@ module ApplicationHelper
   end
 
   def study_link(label, url)
-    if study_id = url.match(/studyno=(\d+)$/)
+    if study_id = url&.match(/studyno=(\d+)$/)
       study = Study.where(studynum: (study_id[1]).to_s).take
       unless study.nil?
         link_to('View Data Files', study_path(study))

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -56,7 +56,7 @@
 
   <div id="main-container" class="<%= container_classes %>">
     <%= render partial: 'shared/flash_msg', layout: 'shared/flash_messages' %>
-    <div class="row">
+    <div class="row <%= admin_screen? ? 'admin' : '' %>">
       <%= content_for?(:content) ? yield(:content) : yield %>
     </div>
   </div>

--- a/spec/system/resources_spec.rb
+++ b/spec/system/resources_spec.rb
@@ -40,4 +40,25 @@ RSpec.describe 'resources', type: :system do
     expect(page).to have_content('Spain')
     expect(page).to have_content('Uganda')
   end
+
+  describe('edit page') do
+    it 'has an .admin class, since it is an admin screen' do
+      visit '/resources/3/edit'
+      expect(page).to have_selector('.admin')
+    end
+  end
+
+  describe('index page') do
+    it 'has an .admin class, since it is an admin screen' do
+      visit '/resources'
+      expect(page).to have_selector('.admin')
+    end
+  end
+
+  describe('admin show page') do
+    it 'has an .admin class, since it is an admin screen' do
+      visit '/resources/3'
+      expect(page).to have_selector('.admin')
+    end
+  end
 end

--- a/spec/system/show_page_spec.rb
+++ b/spec/system/show_page_spec.rb
@@ -15,4 +15,9 @@ RSpec.describe 'Show page', type: :system do
     visit '/catalog/resource3'
     expect(page).not_to have_link('Cite')
   end
+
+  it 'does not have an .admin class, since it is not an admin screen' do
+    visit '/catalog/resource3'
+    expect(page).not_to have_selector('.admin')
+  end
 end


### PR DESCRIPTION
Also, handle the case where a study doesn't have a URL (previously gave an error in the admin show page)

closes #390 