### PR TITLE
Remove cancancan gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -17,12 +17,6 @@ gem 'jquery-rails'
 #gem 'turbolinks', '~> 5'
 # Build JSON APIs with ease. Read more: https://github.com/rails/jbuilder
 gem 'jbuilder', '~> 2.5'
-# Use Redis adapter to run Action Cable in production
-# gem 'redis', '~> 3.0'
-# Use ActiveModel has_secure_password
-# gem 'bcrypt', '~> 3.1.7'
-
-gem 'cancancan', '~> 1.15'
 
 gem 'pg'
 gem "blacklight", '~> 8.0.1'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -109,7 +109,6 @@ GEM
       sassy-maps (< 1.0.0)
     builder (3.2.4)
     byebug (11.1.3)
-    cancancan (1.17.0)
     capistrano (3.16.0)
       airbrussh (>= 1.0.0)
       i18n
@@ -419,7 +418,6 @@ DEPENDENCIES
   blacklight (~> 8.0.1)
   bootstrap (~> 4.6)
   byebug
-  cancancan (~> 1.15)
   capistrano (~> 3.16.0)
   capistrano-passenger
   capistrano-rails

--- a/app/models/data_file.rb
+++ b/app/models/data_file.rb
@@ -1,3 +1,3 @@
 class DataFile < ApplicationRecord
-  belongs_to :study
+  belongs_to :study, optional: true
 end

--- a/app/models/study.rb
+++ b/app/models/study.rb
@@ -6,7 +6,7 @@ class Study < ApplicationRecord
   has_and_belongs_to_many :countries
   has_and_belongs_to_many :regions
   has_many :data_files
-  belongs_to :resource
+  belongs_to :resource, optional: true
   accepts_nested_attributes_for :data_files, reject_if: lambda {|attributes| attributes['files'].blank?}
 
   # remove until import is taken care of.


### PR DESCRIPTION
We weren't using it, except for the cancancan implementation of `belongs_to` found in two of the models.  Let's use the Rails implementation of `belongs_to` instead.