### PR TITLE
Update node to 20.11.1 

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -52,7 +52,7 @@ jobs:
             - ./vendor/bundle
       - node/install:
           install-yarn: true
-          node-version: '18.2.0'
+          node-version: '20.11.1'
       - node/install-packages:
           pkg-manager: yarn
       - run:

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,3 +1,3 @@
 ruby 3.1.3
-nodejs 18.2.0
+nodejs 20.11.1
 yarn 1.22.18


### PR DESCRIPTION
closes #414 
sibling [ansible PR#4690]( https://github.com/pulibrary/princeton_ansible/pull/4690)
related to related to [dacsHandbook#157](https://github.com/pulibrary/dacs_handbook/issues/157)