### PR TITLE
Remove comments that use outdated language

### DIFF
--- a/app/controllers/countries_controller.rb
+++ b/app/controllers/countries_controller.rb
@@ -69,7 +69,6 @@ class CountriesController < ApplicationController
       @country = Country.find(params[:id])
     end
 
-    # Never trust parameters from the scary internet, only allow the white list through.
     def country_params
       params.require(:country).permit(:name, :key_term_id)
     end

--- a/app/controllers/data_files_controller.rb
+++ b/app/controllers/data_files_controller.rb
@@ -68,7 +68,6 @@ class DataFilesController < ApplicationController
       @data_file = DataFile.find(params[:id])
     end
 
-    # Never trust parameters from the scary internet, only allow the white list through.
     def data_file_params
       params.require(:data_file).permit(:legacy_id, :files, :size, :comp_size, :line_count, :line_length, :part, :file_type_a, :file_type_b, :flag_one, :flag_two, :file_type_a, :file_type_tech, :note, :study_num, :permission, :timestamp, :study_id)
     end

--- a/app/controllers/regions_controller.rb
+++ b/app/controllers/regions_controller.rb
@@ -69,7 +69,6 @@ class RegionsController < ApplicationController
       @region = Region.find(params[:id])
     end
 
-    # Never trust parameters from the scary internet, only allow the white list through.
     def region_params
       params.require(:region).permit(:name, :key_term_id)
     end

--- a/app/controllers/resources_controller.rb
+++ b/app/controllers/resources_controller.rb
@@ -73,7 +73,6 @@ class ResourcesController < ApplicationController
       @resource = Resource.find(params[:id])
     end
 
-    # Never trust parameters from the scary internet, only allow the white list through.
     def resource_params
       resource_params = params.require(:resource).permit(:name, :resource_id, :url, :blurb,
                                                          :link_time, :sample, :principal_investigator,

--- a/app/controllers/subjects_controller.rb
+++ b/app/controllers/subjects_controller.rb
@@ -69,7 +69,6 @@ class SubjectsController < ApplicationController
       @subject = Subject.find(params[:id])
     end
 
-    # Never trust parameters from the scary internet, only allow the white list through.
     def subject_params
       params.require(:subject).permit(:name, :key_term_id)
     end


### PR DESCRIPTION
They don't add much to understanding these methods, from my perspective, so I decided to remove them rather than re-word them.