### PR TITLE
Don't send Blacklight::Exceptions::RecordNotFound exceptions to Honeybadger

### DIFF
--- a/config/honeybadger.yml
+++ b/config/honeybadger.yml
@@ -1,2 +1,3 @@
 exceptions:
   rake_rescue: true
+  ignore: 'Blacklight::Exceptions::RecordNotFound'


### PR DESCRIPTION
Related to #275.  This doesn't solve the problem, but it reduces the noise we see in Honeybadger before we complete #275