### PR TITLE
Don't send ActionDispatch::RemoteIp::IpSpoofAttackError to honeybadger

### DIFF
--- a/config/honeybadger.yml
+++ b/config/honeybadger.yml
@@ -1,3 +1,5 @@
 exceptions:
   rake_rescue: true
-  ignore: 'Blacklight::Exceptions::RecordNotFound'
+  ignore:
+    - 'Blacklight::Exceptions::RecordNotFound'
+    - 'ActionDispatch::RemoteIp::IpSpoofAttackError'


### PR DESCRIPTION
This is Rails acting as it should, blocking a potential IP Spoof.  No need to include it in honeybadger.