### PR TITLE
Upgrade jbuilder gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -16,7 +16,7 @@ gem 'health-monitor-rails', '12.4.0'
 gem 'jquery-rails'
 
 # Build JSON APIs with ease. Read more: https://github.com/rails/jbuilder
-gem 'jbuilder', '~> 2.5'
+gem 'jbuilder'
 
 gem 'pg'
 gem "blacklight", '~> 8.3.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -97,7 +97,7 @@ GEM
     bcrypt (3.1.20)
     bcrypt_pbkdf (1.1.0)
     benchmark (0.4.0)
-    bigdecimal (3.1.8)
+    bigdecimal (3.1.9)
     blacklight (8.3.0)
       globalid
       i18n (>= 1.7.0)
@@ -143,8 +143,8 @@ GEM
     ckeditor (5.1.3)
       orm_adapter (~> 0.5.0)
     coderay (1.1.3)
-    concurrent-ruby (1.3.4)
-    connection_pool (2.4.1)
+    concurrent-ruby (1.3.5)
+    connection_pool (2.5.0)
     crack (1.0.0)
       bigdecimal
       rexml
@@ -162,7 +162,7 @@ GEM
     drb (2.2.1)
     dry-cli (1.0.0)
     ed25519 (1.3.0)
-    erubi (1.13.0)
+    erubi (1.13.1)
     execjs (2.9.1)
     factory_bot (6.5.0)
       activesupport (>= 5.0.0)
@@ -181,13 +181,13 @@ GEM
     health-monitor-rails (12.4.0)
       railties (>= 6.1)
     honeybadger (5.4.1)
-    i18n (1.14.6)
+    i18n (1.14.7)
       concurrent-ruby (~> 1.0)
     io-console (0.7.2)
     irb (1.14.0)
       rdoc (>= 4.0.0)
       reline (>= 0.4.2)
-    jbuilder (2.11.5)
+    jbuilder (2.13.0)
       actionview (>= 5.0.0)
       activesupport (>= 5.0.0)
     jquery-datatables-rails (3.4.0)
@@ -215,8 +215,8 @@ GEM
       kaminari-core (= 1.2.2)
     kaminari-core (1.2.2)
     language_server-protocol (3.17.0.3)
-    logger (1.6.2)
-    loofah (2.23.1)
+    logger (1.7.0)
+    loofah (2.24.0)
       crass (~> 1.0.2)
       nokogiri (>= 1.12.0)
     mail (2.8.1)
@@ -229,7 +229,7 @@ GEM
     method_source (1.0.0)
     mini_mime (1.1.5)
     mini_portile2 (2.8.8)
-    minitest (5.25.4)
+    minitest (5.25.5)
     modernizr-rails (2.7.1)
     mutex_m (0.3.0)
     net-imap (0.5.6)
@@ -245,7 +245,7 @@ GEM
       net-protocol
     net-ssh (7.2.1)
     nio4r (2.7.3)
-    nokogiri (1.18.4)
+    nokogiri (1.18.7)
       mini_portile2 (~> 2.8.2)
       racc (~> 1.4)
     normalize-rails (3.0.3)
@@ -315,7 +315,7 @@ GEM
       activesupport (>= 5.0.0)
       minitest
       nokogiri (>= 1.6)
-    rails-html-sanitizer (1.6.1)
+    rails-html-sanitizer (1.6.2)
       loofah (~> 2.21)
       nokogiri (>= 1.15.7, != 1.16.7, != 1.16.6, != 1.16.5, != 1.16.4, != 1.16.3, != 1.16.2, != 1.16.1, != 1.16.0.rc1, != 1.16.0)
     railties (7.2.2.1)
@@ -399,7 +399,7 @@ GEM
       tilt
     sassy-maps (0.4.0)
       sass (~> 3.3)
-    securerandom (0.4.0)
+    securerandom (0.4.1)
     select2-rails (4.0.13)
     selenium-webdriver (4.16.0)
       rexml (~> 3.2, >= 3.2.5)
@@ -479,7 +479,7 @@ DEPENDENCIES
   ffi
   health-monitor-rails (= 12.4.0)
   honeybadger
-  jbuilder (~> 2.5)
+  jbuilder
   jquery-rails
   omniauth-cas
   omniauth-rails_csrf_protection


### PR DESCRIPTION
Resolves DEPRECATION WARNING: ActiveSupport::ProxyObject is deprecated and will be removed in Rails 8.0.