### PR TITLE
Remove low-value gems

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -32,11 +32,9 @@ group :development, :test do
   gem "rspec-rails"
   gem 'rails-controller-testing'
   gem "factory_bot_rails", require: false
-  gem "pry-byebug"
   gem "rubocop-rspec", require: false
   gem 'rubocop-rails', require: false
   gem 'selenium-webdriver'
-  gem "timecop"
   gem 'webmock', require: false
 end
 
@@ -50,8 +48,6 @@ group :development do
   gem 'ed25519'
 end
 
-# Windows does not include zoneinfo files, so bundle the tzinfo-data gem
-gem 'tzinfo-data', platforms: [:mingw, :mswin, :x64_mingw, :jruby]
 
 gem 'rsolr'
 gem "devise"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -143,7 +143,6 @@ GEM
     chronic (0.10.2)
     ckeditor (5.1.3)
       orm_adapter (~> 0.5.0)
-    coderay (1.1.3)
     concurrent-ruby (1.3.5)
     connection_pool (2.5.0)
     crack (1.0.0)
@@ -269,12 +268,6 @@ GEM
       racc
     pg (1.5.4)
     popper_js (1.16.1)
-    pry (0.14.2)
-      coderay (~> 1.1)
-      method_source (~> 1.0)
-    pry-byebug (3.10.1)
-      byebug (~> 11.0)
-      pry (>= 0.13, < 0.15)
     psych (5.1.2)
       stringio
     public_suffix (5.1.1)
@@ -424,7 +417,6 @@ GEM
       execjs (>= 0.3.0, < 3)
     thor (1.3.2)
     tilt (2.4.0)
-    timecop (0.9.8)
     timeout (0.4.3)
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
@@ -485,7 +477,6 @@ DEPENDENCIES
   omniauth-cas
   omniauth-rails_csrf_protection
   pg
-  pry-byebug
   pul-assets!
   puma
   rails (~> 7.2)
@@ -499,8 +490,6 @@ DEPENDENCIES
   selenium-webdriver
   sshkit
   terser
-  timecop
-  tzinfo-data
   view_component (~> 2.66)
   vite_rails
   webmock

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe User, type: :model do
     before do
       # There's an initial user that we don't want
       described_class.find_each(&:destroy)
-      Timecop.freeze(Time.now.utc - 10.days) do
+      travel_to(Time.now.utc - 10.days) do
         FactoryBot.create_list(:guest_patron, 100, guest: true)
         FactoryBot.create_list(:user, 10)
       end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -72,4 +72,6 @@ RSpec.configure do |config|
   [:request, :system].each do |type|
     config.include Devise::Test::IntegrationHelpers, type:
   end
+
+  config.include ActiveSupport::Testing::TimeHelpers
 end


### PR DESCRIPTION
* Timecop can be easily replaced with Rails' built-in TimeHelpers
* We don't use tz-info or pry-byebug