### PR TITLE
Update project to comply with new semgrep rules

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -75,16 +75,6 @@ jobs:
       - run:
           name: Run Rspec
           command: bundle exec rspec
-  bearer:
-    docker:
-      - image: cimg/ruby:3.3
-    environment:
-      # Set to default branch of your repo
-      DEFAULT_BRANCH: main
-    steps:
-      - checkout
-      - run: curl -sfL https://raw.githubusercontent.com/Bearer/bearer/main/contrib/install.sh | sh -s -- -b /tmp
-      - run: CURRENT_BRANCH=$CIRCLE_BRANCH SHA=$CIRCLE_SHA1 /tmp/bearer scan .
   semgrep:
     docker:
         - image: returntocorp/semgrep
@@ -118,5 +108,4 @@ workflows:
            branches:
              only:
                - main
-      - bearer
       - semgrep

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,11 +6,11 @@ updates:
     schedule:
       interval: "weekly"
     cooldown:
-      default-days: 3
+      default-days: 7
   - package-ecosystem: "npm" # See documentation for possible values
     directory: "/" # Location of package manifests
     open-pull-requests-limit: 5
     schedule:
       interval: "weekly"
     cooldown:
-      default-days: 3
+      default-days: 7

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -40,11 +40,11 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v3
+      uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v2
+      uses: github/codeql-action/init@e58424170fb0262c8d7ed60a2e84b9bffe205c67
       with:
         languages: ${{ matrix.language }}
         # If you wish to specify custom queries, you can do so here or in a config file.
@@ -58,7 +58,7 @@ jobs:
     # Autobuild attempts to build any compiled languages  (C/C++, C#, Go, or Java).
     # If this step fails, then you should remove it and run the build manually (see below)
     - name: Autobuild
-      uses: github/codeql-action/autobuild@v2
+      uses: github/codeql-action/autobuild@e58424170fb0262c8d7ed60a2e84b9bffe205c67
 
     # ℹ️ Command-line programs to run using the OS shell.
     # 📚 See https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepsrun
@@ -71,6 +71,6 @@ jobs:
     #     ./location_of_script_within_repo/buildscript.sh
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v2
+      uses: github/codeql-action/analyze@e58424170fb0262c8d7ed60a2e84b9bffe205c67
       with:
         category: "/language:${{matrix.language}}"


### PR DESCRIPTION
* Increase dependabot cooldown period to 7 days
* Remove bearer, which is installed in an insecure way
* Pin codeql workflows to specific commits